### PR TITLE
Fixes quotes around file names on Mac for runModels

### DIFF
--- a/R/runModels.R
+++ b/R/runModels.R
@@ -435,7 +435,7 @@ runModels <- function(directory=getwd(), recursive=FALSE, filefilter = NULL, sho
 	else{
 		if(showOutput) stdout.value = ""
 		else stdout.value = NULL
-	 	system2(Mplus_command, args=paste('"',inputSplit$filename,'"',sep=""), stdout=stdout.value, wait=TRUE)
+	 	system2(Mplus_command, args=c(shQuote(inputSplit$filename)), stdout=stdout.value, wait=TRUE)
 	 }
 
   }


### PR DESCRIPTION
This is a one-line fix. More generally, shQuotes should be adapted through the package where quotes are needed when passing file names.
