### PR TITLE
Fix for multigroup models, where Observations were not parsed correctly

### DIFF
--- a/R/parseOutput.R
+++ b/R/parseOutput.R
@@ -758,6 +758,10 @@ extractSummaries_1file <- function(outfiletext, filename, input)
   
   arglist$Estimator <- extractValue(pattern="^\\s*Estimator\\s*", analysisSummarySection, filename, type="str")
   arglist$Observations <- extractValue(pattern="^\\s*Number of observations\\s*", analysisSummarySection, filename, type="int")
+  # Fix for multigroup models, where Observations were not parsed correctly
+  if(is.na(arglist$Observations)){
+    arglist$Observations <- extractValue(pattern="^\\s*Total sample size\\s*", analysisSummarySection, filename, type="int")
+  }
   arglist$NGroups <- extractValue(pattern="^\\s*Number of groups\\s*", analysisSummarySection, filename, type="int")
   arglist$NDependentVars <- extractValue(pattern="^\\s*Number of dependent variables\\s*", analysisSummarySection, filename, type="int")
   arglist$NIndependentVars <- extractValue(pattern="^\\s*Number of independent variables\\s*", analysisSummarySection, filename, type="int")


### PR DESCRIPTION
I'm working on a package with downstream dependencies on MplusAutomation, and realized that this section of the Mplus output is not parsed correctly. Currently, $summaries$Observations is missing for multi-group models.

```
Number of observations
   Group MALE                                                  500
   Group FEMALE                                                600
   Total sample size                                          1100
```

My fix returns the Total sample size as $summaries$Observations, and $summaries gains an attribute "Observations" with the number of observations per group.