### PR TITLE
add '/d' flag to cd command for windows

### DIFF
--- a/R/runModels.R
+++ b/R/runModels.R
@@ -450,7 +450,7 @@ runModels <- function(target=getwd(), recursive=FALSE, filefilter = NULL, showOu
     #navigate to working directory in DOS using cd command so that Mplus finds the appropriate files (support rel paths)
     #switched over to use relative filename because of problems in Mplus via Wine misinterpreting absolute paths due to forward slashes.
     #25Jul2012: Quote Mplus_command in case it's in a path with spaces.
-    command <- paste("cd \"", inputSplit$directory, "\" && \"", Mplus_command, "\" \"", inputSplit$filename, "\"", sep="")
+    command <- paste("cd /d \"", inputSplit$directory, "\" && \"", Mplus_command, "\" \"", inputSplit$filename, "\"", sep="")
 
     #allow for divergence if the package is being run in Linux (Mplus via wine)
     if (is.windows()) {


### PR DESCRIPTION
without the `/d` flag, `cd` does not change directory so if your temporary user directory is located on a different drive as your working directory, `cd` does not work as intended.

Besides using the `/d` flag, there are 2 options.
    1. use `pushd` instead  which imo works more reliably for scripting purposes.
    2. just provide full file paths to the mplus exe. on linux, there are `readlinks` and `realpath`. On windows there are `%dpf~1`` for batch files  which resolves to the full path of the first argument provided.