### PR TITLE
Fixed covariance coverage subsection warning and NAs in the group observations from read.Models()

### DIFF
--- a/R/parseOutput.R
+++ b/R/parseOutput.R
@@ -1476,9 +1476,9 @@ extractCovarianceCoverage <- function(outfiletext, filename) {
   
   covcoverageList <- list()
   
-  covcoverageSubsections <- getMultilineSection("PROPORTION OF DATA PRESENT( FOR [\\w\\d\\s\\.,_]+)*",
+  covcoverageSubsections <- getMultilineSection("PROPORTION OF DATA PRESENT FOR \\w+(?:\\s+\\(\\d+\\))*\\s*$",
     covcoverageSection, filename, allowMultiple=TRUE)
-  
+
   matchlines <- attr(covcoverageSubsections, "matchlines")
   
   if (length(covcoverageSubsections) == 0 || all(is.na(covcoverageSubsections))) { #See UG ex9.7.out

--- a/R/readModels.R
+++ b/R/readModels.R
@@ -177,8 +177,8 @@ readModels <- function(target=getwd(), recursive=FALSE, filefilter, what="all", 
           obs <- gsub("Group", "", obs)
           obs <- unlist(strsplit(trimws(obs), "\\s+"))
           if (isTRUE(length(obs) %% 2 == 0)) {
-            Observations <- as.numeric(obs[seq(2, to = length(obs), by = 2)])
-            names(Observations) <- obs[seq(1, to = length(obs), by = 2)]
+            Observations <- as.numeric(obs[seq(3, to = length(obs), by = 3)])
+            names(Observations) <- obs[seq(1, to = length(obs), by = 3)]
             attr(allFiles[[listID]]$summaries, "Observations") <- Observations
           }
         }


### PR DESCRIPTION
Using Mplus version 8.11 + the current MplusAutomation#master
Using this datafile: [simdata.txt](https://github.com/michaelhallquist/MplusAutomation/files/15434836/simdata.txt)

and this code:
```R
library(MplusAutomation)

data <- read.csv("simdata.txt", header = F, fill = T, sep = "")
colnames(data)[11] <- "group"
  
alignment.mdl <- mplusObject(
  TITLE =     "Run alignment with oblimin rotation;",
  VARIABLE =  "USEVARIABLES = group V1-V10; GROUPING =  group(2);",
  MODEL= "F1-F2 BY V1-V10(*1);",
  ANALYSIS =  "ROTATION = OBLIMIN; alignment = fixed",
  OUTPUT = "align tech1;",
  rdata = data
)

alignment.fit <- mplusModeler(alignment.mdl, modelout = "alignment_model.inp", run=T)
```
I get the following error messages:
```
No PROPORTION OF DATA PRESENT sections found within COVARIANCE COVERAGE OF DATA output.
Warning message:
In readModels(target = outfile, quiet = quiet) : NAs introduced by coercion
```
which are fixed in this pull request. 

Would it be possible to check if this is correct and working for other Mplus versions and on other datasets? And if everything is correct, then would it be possible for you to add this to the next release of MplusAutomation?

Many thanks!