### PR TITLE
Fix indirect effect parsing for hurdle models

### DIFF
--- a/R/extractIndirect.R
+++ b/R/extractIndirect.R
@@ -86,7 +86,7 @@ extractIndirect_section <- function(indirectSection, curfile, sectionType) {
   for (idx in 1:length(isplit)) {
     i_element <- isplit[[idx]]
     i_out <- list()
-    effectHeaders <- grep("^Effects from [A-z_0-9]+ to [A-z_0-9]+$", i_element, ignore.case=TRUE, perl=TRUE)
+    effectHeaders <- grep("^Effects from [\\w#]+ to [\\w#]+$", i_element, ignore.case=TRUE, perl=TRUE)
     if (length(effectHeaders) == 0L) { next } #nothing to parse -- skip to next iteration
     
     #determine group name, if relevant
@@ -98,8 +98,8 @@ extractIndirect_section <- function(indirectSection, curfile, sectionType) {
     
     for (e in 1:length(effectHeaders)) {
       elist <- list()
-      elist$pred <- sub("^Effects from ([A-z_0-9]+) to [A-z_0-9]+$", "\\1", i_element[effectHeaders[e]], ignore.case=TRUE, perl=TRUE)
-      elist$outcome <- sub("^Effects from [A-z_0-9]+ to ([A-z_0-9]+)$", "\\1", i_element[effectHeaders[e]], ignore.case=TRUE, perl=TRUE)
+      elist$pred <- sub("^Effects from ([\\w#]+) to [\\w#]+$", "\\1", i_element[effectHeaders[e]], ignore.case=TRUE, perl=TRUE)
+      elist$outcome <- sub("^Effects from [\\w#]+ to ([\\w#]+)$", "\\1", i_element[effectHeaders[e]], ignore.case=TRUE, perl=TRUE)
       
       end <- ifelse (e < length(effectHeaders), effectHeaders[e+1]-1, length(i_element))
       esection <- i_element[(effectHeaders[e]+1):end]

--- a/tests/testthat/nbh_indirect.out
+++ b/tests/testthat/nbh_indirect.out
@@ -1,0 +1,37 @@
+INPUT INSTRUCTIONS
+
+ this is a stub
+
+SUMMARY OF ANALYSIS
+
+ this is a stub
+
+TOTAL, TOTAL INDIRECT, SPECIFIC INDIRECT, AND DIRECT EFFECTS
+
+Effects from MYIV to DVNB
+
+  Total               -0.015      0.230     -0.063      0.950
+  Total indirect       0.035      0.062      0.567      0.571
+
+  Specific indirect 1
+    DVNB
+    MYMED
+    MYIV               0.035      0.062      0.567      0.571
+
+  Direct
+    DVNB
+    MYIV              -0.050      0.225     -0.222      0.824
+
+Effects from MYIV to DVNB#1
+
+  Total                0.631      0.262      2.410      0.016
+  Total indirect      -0.080      0.076     -1.047      0.295
+
+  Specific indirect 1
+    DVNB#1
+    MYMED
+    MYIV              -0.080      0.076     -1.047      0.295
+
+  Direct
+    DVNB#1
+    MYIV               0.711      0.264      2.695      0.007

--- a/tests/testthat/test-issue217.R
+++ b/tests/testthat/test-issue217.R
@@ -1,0 +1,6 @@
+test_that("indirect effects with # in outcome are parsed", {
+  m <- readModels(target = testthat::test_path("nbh_indirect.out"), what = "indirect")
+  ind <- get_indirect(m)
+  expect_true(any(ind$unstandardized$overall$outcome == "DVNB#1"))
+  expect_true(any(ind$unstandardized$overall$outcome == "DVNB"))
+})


### PR DESCRIPTION
## Summary
- Handle variable names containing `#` when extracting indirect effects
- Add regression test for hurdle model indirect effects

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689be31fd3d8832198a38d1e2688e01e